### PR TITLE
Use Emacs' `auth-source`

### DIFF
--- a/ovpn-mode.el
+++ b/ovpn-mode.el
@@ -146,7 +146,7 @@ Return a LIST of user and password for a given config or NIL."
 (defun ovpn-mode-clear-authinfo-cache ()
   "Call this if you add new `ovpn-mode' authinfo data in a running Emacs instance."
   (interactive)
-  (setq netrc-cache nil))
+  (auth-source-forget-all-cached))
 
 ;;; major mode for future buffer and keymap enhancements
 (defvar ovpn-mode-keywords '("ovpn"))

--- a/ovpn-mode.el
+++ b/ovpn-mode.el
@@ -125,7 +125,10 @@ Searches for an entry where `:host` matches the ovpn CONFIG file name
 (e.g., \"myvpn.ovpn\").
 
 Example authinfo entry: machine CONFIG.OVPN login USER password PASS
-
+Example password-store entry: ```
+PASS
+user: USER
+```
 Return a LIST of user and password for a given config or NIL."
     (let* ((host (file-name-nondirectory config))
            (entry (car (auth-source-search :host host

--- a/ovpn-mode.el
+++ b/ovpn-mode.el
@@ -103,11 +103,6 @@
 ;; used for keyword filtering of .ovpn listings
 (defvar ovpn-mode-base-filter nil)
 
-(defcustom ovpn-mode-authinfo-path "~/.authinfo.gpg"
-  "Path to authinfo data."
-  :type 'string
-  :group 'ovpn)
-
 (defcustom ovpn-mode-check-authinfo t
   "Check authinfo for configname.ovpn associated user:pass data."
   :type 'boolean


### PR DESCRIPTION
Hi, thanks a lot for this package.

I use [`password-store`](https://www.passwordstore.org/) to manage my passwords outside of and in Emacs:

```elisp
(use-package auth-source-pass
  :config
  (auth-source-pass-enable))

(use-package auth-source
  :after auth-source-pass
  :init
  (setq auth-sources '(password-store)))
```

But it seems this package hardcodes the use of netrc files.

I've made these changes so anyone can use any backend instead.

Even if you don't think it's valuable for this to be merged, just leaving it here in case someone runs into the same issue

Thanks